### PR TITLE
refactor(ui): remove inline shortcut text; keep shortcuts modal only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -891,6 +891,19 @@ Reminder + notification invariants:
   - `POST /api/social-posts/overdue-checks`
   - `POST /api/blogs/overdue-checks`
 
+## Shortcut Display Invariants (MUST)
+
+Keyboard shortcut information must live in exactly one place: the shared shortcuts modal. Main pages and detail editors must not advertise keybindings inline.
+
+1. Do NOT render key-combo text on pages or sidebars (for example `Shortcut: ⌥⇧J`, `Primary action: ⌥⇧↵`, or `Press Q to open, ESC to close`).
+2. The only discoverability affordance allowed on a page is a clickable text labeled `Shortcut` (or `Shortcuts`) that opens the shared shortcuts modal.
+3. The shortcuts modal is the single source of truth for all global, create, and page-aware shortcut keys, grouped per page scope (`pageShortcuts` in `src/components/app-shell.tsx`).
+4. Dropdown/command menu items (for example Quick Create rows `New Blog`, `New Idea`, `New Social Post`) may display a per-item `KbdShortcut` badge next to the action. This is an item affordance, not on-page prose, and remains allowed.
+5. Keydown handlers (for example `Alt+Shift+J`, `Alt+Shift+Enter` on `/blogs/[id]` and `/social-posts/[id]`) stay functional; only the on-page text description is removed.
+6. `aria-keyshortcuts` attributes on primary action buttons are kept for accessibility (screen reader / assistive technology), since they do not render visible text.
+7. Do not reintroduce explanatory sentences like `Use Up/Down to move and Enter to select` in Quick Create or similar panels. Arrow-key behavior is expected and the single `Shortcut` link is sufficient for discoverability.
+8. Naming: the clickable discoverability affordance uses the singular word `Shortcut` (title-case). Inside the modal, keep the heading `Shortcuts`.
+
 ## UI Label Standards (MUST)
 
 **Avoid labeling user roles in section headers** unless explicitly necessary for admin-only features:

--- a/HOW_TO_USE_APP.md
+++ b/HOW_TO_USE_APP.md
@@ -166,6 +166,7 @@ Shared detail-page usability helpers:
 - Responsive right rail behavior is consistent on both detail pages:
   - `lg` and above: right rail is visible and sticky.
   - Below `lg`: right-rail cards move into the main vertical flow (no side column).
+- Keyboard shortcuts for detail pages (jump to next required field, run primary action) are documented only in the shared shortcuts modal (profile menu → `Shortcuts`). Main pages no longer print key combos inline.
 
 ## Ask AI (guidance-only)
 Ask AI lives on blog, social post, and idea detail pages. It never edits records or runs transitions.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -59,6 +59,7 @@ npm run check:full
 - Blog detail uses preflight readiness + jump-to-field guidance and keyboard parity shortcuts:
   - `Alt+Shift+J` (next missing required field)
   - `Alt+Shift+Enter` (primary action)
+  - These shortcuts are surfaced exclusively in the shared shortcuts modal; detail pages must not render inline `Shortcut: …` / `Primary action: …` text.
 
 ### Blogs
 - Writing flow handoff to publishing remains enforced.

--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -1277,10 +1277,6 @@ export default function BlogDetailPage() {
                   )}
                 </>
               )}
-              <p className="text-[11px] text-slate-500">
-                Shortcut: {BLOG_DETAIL_SHORTCUTS.nextRequired.keys[0]} • Primary action:{" "}
-                {BLOG_DETAIL_SHORTCUTS.primaryAction.keys[0]}
-              </p>
             </div>
           </section>
           <nav
@@ -1990,10 +1986,6 @@ export default function BlogDetailPage() {
                         )}
                       </>
                     )}
-                    <p className="text-[11px] text-slate-500">
-                      Shortcut: {BLOG_DETAIL_SHORTCUTS.nextRequired.keys[0]} • Primary action:{" "}
-                      {BLOG_DETAIL_SHORTCUTS.primaryAction.keys[0]}
-                    </p>
                   </div>
                 </section>
                 <nav

--- a/src/app/social-posts/[id]/page.tsx
+++ b/src/app/social-posts/[id]/page.tsx
@@ -1877,10 +1877,6 @@ export default function SocialPostEditorPage() {
                   ready.
                 </p>
               )}
-              <p className="text-[11px] text-slate-500">
-                Shortcut: {SOCIAL_POST_EDITOR_SHORTCUTS.nextRequired.keys[0]} • Primary action:{" "}
-                {SOCIAL_POST_EDITOR_SHORTCUTS.primaryAction.keys[0]}
-              </p>
             </div>
           </section>
           <nav
@@ -3023,21 +3019,6 @@ export default function SocialPostEditorPage() {
                   >
                     {isSaving ? "Saving…" : finalAction.label}
                   </Button>
-                  <p className="text-[11px] text-slate-500">
-                    <button
-                      type="button"
-                      className="font-medium text-slate-700 underline-offset-2 hover:underline"
-                      onClick={() => {
-                        window.dispatchEvent(new CustomEvent("open-shortcuts-modal"));
-                      }}
-                    >
-                      Shortcut
-                    </button>{" "}
-                    {SOCIAL_POST_EDITOR_SHORTCUTS.nextRequired.label}:{" "}
-                    {SOCIAL_POST_EDITOR_SHORTCUTS.nextRequired.keys[0]} •{" "}
-                    {SOCIAL_POST_EDITOR_SHORTCUTS.primaryAction.label}:{" "}
-                    {SOCIAL_POST_EDITOR_SHORTCUTS.primaryAction.keys[0]}
-                  </p>
                   {!canActOnCurrentStatus ? (
                     <p className="text-xs text-amber-700">{ASSIGNED_USER_HELPER_TEXT}</p>
                   ) : null}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1064,20 +1064,18 @@ export function AppShell({
                 ))}
               </div>
             </div>
-            <p className="mt-4 text-xs text-slate-500">
-              Use <KbdShortcut>Up</KbdShortcut>/<KbdShortcut>Down</KbdShortcut> to move and <KbdShortcut>Enter</KbdShortcut> to select.{" "}
+            <div className="mt-4 flex justify-end">
               <button
                 type="button"
-                className="font-medium text-slate-700 underline-offset-2 hover:underline"
+                className="text-xs font-medium text-slate-700 underline-offset-2 hover:underline"
                 onClick={() => {
                   setIsQuickCreateOpen(false);
                   setIsShortcutModalOpen(true);
                 }}
               >
-                Shortcuts
-              </button>{" "}
-              details
-            </p>
+                Shortcut
+              </button>
+            </div>
           </section>
         </div>
       ) : null}

--- a/src/components/global-quick-create.tsx
+++ b/src/components/global-quick-create.tsx
@@ -156,9 +156,6 @@ export function GlobalQuickCreate() {
             >
               Create New
             </h2>
-            <p className="text-sm text-gray-500 mt-1">
-              Press {QUICK_CREATE_SHORTCUT_KEY} to open, ESC to close
-            </p>
           </div>
 
           {/* Actions */}


### PR DESCRIPTION
Removes stray on-page shortcut copy from main pages; shortcut info now lives exclusively in the shared Shortcuts modal.

Scope
- src/app/blogs/[id]/page.tsx — remove duplicated 'Shortcut: ⌥⇧J • Primary action: ⌥⇧↵' on mobile + sticky-desktop preflight
- src/app/social-posts/[id]/page.tsx — remove same preflight line + longer checklist-sidebar Shortcut prose
- src/components/app-shell.tsx — replace Quick Create footer prose ('Use ↑/↓ … Shortcuts details') with a single right-aligned clickable Shortcut link that opens the modal
- src/components/global-quick-create.tsx — drop 'Press Q to open, ESC to close' subtitle

Docs
- AGENTS.md — new 'Shortcut Display Invariants (MUST)' section
- HOW_TO_USE_APP.md — user-facing note on shortcut modal being the single source
- OPERATIONS.md — clarify blog detail keyboard parity surfaces only via modal

Behavior preserved
- All keydown handlers, per-item <KbdShortcut> badges, and aria-keyshortcuts remain intact.

Risk: Low (UI-only).